### PR TITLE
PC-Front(국문) - more → 더 보기, Back to list → 목록, 각 섹션 타이틀이 대문자, 카드 타이틀의 색상, NEWS 그림자가 노출

### DIFF
--- a/efhiefh2ui344fwe/html/contact_us.html
+++ b/efhiefh2ui344fwe/html/contact_us.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="../pc/css/reset.css">
   <link rel="stylesheet" href="../pc/css/swiper-bundle.min.css"/>
   <link rel="stylesheet" href="../pc/css/common.css">
-  <title>Contact</title>  
+  <title>CONTACT</title>  
   <script src="../pc/js/vendor/jquery-2.1.3.min.js"></script>
   <script src="../pc/js/vendor/gsap.min.js"></script>
   <script src="../pc/js/vendor/ScrollTrigger.min.js"></script>
@@ -76,7 +76,9 @@
             <span class="section1-start"></span>
             <h2 class="blind">Information</h2>
             <h3 class="motion-tit">
-              <span>Contact</span>
+              <!-- 2022-12-19 수정 시작 -->
+              <span>CONTACT</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h3>
             
             <div class="information">

--- a/efhiefh2ui344fwe/html/main.html
+++ b/efhiefh2ui344fwe/html/main.html
@@ -151,7 +151,9 @@
         <section class="section section2">
           <div class="section-inner">
 
-            <h2 class="tit">Brand Vision</h2>
+            <!-- 2022-12-19 수정 시작 -->
+            <h2 class="tit">BRAND VISION</h2>
+            <!-- // 2022-12-19 수정 끝 -->
 
             <div class="vision-list-area">
               <ul class="vision-list">
@@ -305,7 +307,9 @@
         <section class="section section4">
           <div class="section-inner">
           
-            <h2 class="tit">News</h2>
+            <!-- 2022-12-19 수정 시작 -->
+            <h2 class="tit">NEWS</h2>
+            <!-- // 2022-12-19 수정 끝 -->
 
             <div class="news-list-area">
               <ul class="news-list">

--- a/efhiefh2ui344fwe/html/main2.html
+++ b/efhiefh2ui344fwe/html/main2.html
@@ -114,7 +114,9 @@
 
         <section class="section section2">
           <div class="section2-trigger"></div>
-          <h2 class="tit">Works</h2>
+          <!-- 2022-12-19 수정 시작 -->
+          <h2 class="tit">WORKS</h2>
+          <!-- // 2022-12-19 수정 끝 -->
 
           <div class="works-slide">
             <div class="swiper-wrapper">
@@ -191,7 +193,9 @@
 
         <section class="section section4">
           <div class="tit-area">
-            <h2 class="tit">Partners</h2>
+            <!-- 2022-12-19 수정 시작 -->
+            <h2 class="tit">PARTNERS</h2>
+            <!-- // 2022-12-19 수정 끝 -->
             <a href="#" class="btn-more">view more partners</a>
           </div>
 

--- a/efhiefh2ui344fwe/html/news_contents.html
+++ b/efhiefh2ui344fwe/html/news_contents.html
@@ -75,7 +75,9 @@
           <div class="inner">
             <h2 class="blind">News</h2>
             <h3 class="motion-tit">
-              <span>Press</span>
+              <!-- 2022-12-19 수정 시작 -->
+              <span>PRESS</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h3>
             
             <div class="news-contents-wrap">
@@ -89,16 +91,28 @@
                     <div class="swiper-slide">
                       <div class="contents-img">
                         <img src="../pc/images/sub/news_cont_imgs03.png" alt="">
+
+                        <!-- 2022-12-19 추가 시작 -->
+                        <p>왼쪽부터 이덕재 CCO, 신정수 콘텐츠제작센터장, 이상진 콘텐츠IP사업담당이 새로운 조직인 STUDIO X+U를 소개하고 있다.</p>
+                        <!-- // 2022-12-19 추가 끝 -->
                       </div>
                     </div>
                     <div class="swiper-slide">
                       <div class="contents-img">
                         <img src="../pc/images/sub/news_cont_imgs03.png" alt="">
+
+                        <!-- 2022-12-19 추가 시작 -->
+                        <p>왼쪽부터 이덕재 CCO, 신정수 콘텐츠제작센터장, 이상진 콘텐츠IP사업담당이 새로운 조직인 STUDIO X+U를 소개하고 있다.</p>
+                        <!-- // 2022-12-19 추가 끝 -->
                       </div>
                     </div>
                     <div class="swiper-slide">
                       <div class="contents-img">
                         <img src="../pc/images/sub/news_cont_imgs03.png" alt="">
+
+                        <!-- 2022-12-19 추가 시작 -->
+                        <p>왼쪽부터 이덕재 CCO, 신정수 콘텐츠제작센터장, 이상진 콘텐츠IP사업담당이 새로운 조직인 STUDIO X+U를 소개하고 있다.</p>
+                        <!-- // 2022-12-19 추가 끝 -->
                       </div>
                     </div>
                   </div>
@@ -136,7 +150,7 @@
             <div class="contents-pagination type2">
               <ul>
                 <li><a href="#" class="prev"><span class="blind">이전</span></a></li>
-                <li><a href="#" class="go-list">Back to list<span class="blind">목록으로 이동</span></a></li>
+                <li><a href="#" class="go-list">목록<span class="blind">목록으로 이동</span></a></li>
                 <li><a href="#" class="next"><span class="blind">다음</span></a></li>
               </ul>
             </div>

--- a/efhiefh2ui344fwe/html/news_list.html
+++ b/efhiefh2ui344fwe/html/news_list.html
@@ -76,7 +76,9 @@
             <span class="section1-start"></span>
             <h2 class="blind">News</h2>
             <h3 class="motion-tit">
-              <span>Press</span>
+              <!-- 2022-12-19 수정 시작 -->
+              <span>PRESS</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h3>
             
             <div class="search-wrap">

--- a/efhiefh2ui344fwe/html/partners.html
+++ b/efhiefh2ui344fwe/html/partners.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="../pc/css/reset.css">
   <link rel="stylesheet" href="../pc/css/swiper-bundle.min.css"/>
   <link rel="stylesheet" href="../pc/css/common.css">
-  <title>Partners</title>  
+  <title>PARTNERS</title>  
   <script src="../pc/js/vendor/jquery-2.1.3.min.js"></script>
   <script src="../pc/js/vendor/gsap.min.js"></script>
   <script src="../pc/js/vendor/ScrollTrigger.min.js"></script>
@@ -76,7 +76,9 @@
             <span class="section1-start"></span>
             <h2 class="blind">About</h2>
             <h3 class="motion-tit">
-              <span>Partners</span>
+              <!-- 2022-12-19 수정 시작 -->
+              <span>PARTNERS</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h3>
 
             <div class="partners-list-wrap">
@@ -159,7 +161,9 @@
             </div>
 
             <div class="contents-pagination type2">
-              <a href="#" class="go-list">more<span class="blind">더보기</span></a>
+              <!-- 2022-12-19 수정 시작 -->
+              <a href="#" class="go-list">더보기<span class="blind">더보기</span></a>
+              <!-- // 2022-12-19 수정 끝 -->
             </div>
 
           </div>

--- a/efhiefh2ui344fwe/html/recruitment.html
+++ b/efhiefh2ui344fwe/html/recruitment.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="../pc/css/reset.css">
   <link rel="stylesheet" href="../pc/css/swiper-bundle.min.css"/>
   <link rel="stylesheet" href="../pc/css/common.css">
-  <title>Recruitment</title>  
+  <title>RECRUITMENT</title>  
   <script src="../pc/js/vendor/jquery-2.1.3.min.js"></script>
   <script src="../pc/js/vendor/gsap.min.js"></script>
   <script src="../pc/js/vendor/ScrollTrigger.min.js"></script>
@@ -76,7 +76,9 @@
             <span class="section1-start"></span>
             <h2 class="blind">Information</h2>
             <h3 class="motion-tit">
-              <span>Recruit</span>
+              <!-- 2022-12-19 수정 시작 -->
+              <span>RECRUIT</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h3>
 
             <div class="search-wrap mt30">

--- a/efhiefh2ui344fwe/html/recruitment_contents.html
+++ b/efhiefh2ui344fwe/html/recruitment_contents.html
@@ -75,7 +75,9 @@
           <div class="inner">
             <h2 class="blind">Information</h2>
             <h3 class="motion-tit">
-              <span>Recruit</span> <!-- 2022.12.14 텍스트수정 -->
+              <!-- 2022-12-19 수정 시작 -->
+              <span>RECRUIT</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h3>
             
             <div class="news-contents-wrap ver-recruit">
@@ -148,7 +150,9 @@
             <div class="contents-pagination">
               <ul>
                 <li><a href="#" class="prev"><span class="blind">이전</span></a></li>
-                <li><a href="#" class="go-list">Back to list<span class="blind">목록으로 이동</span></a></li>
+                <!-- 2022-12-19 수정 시작 -->
+                <li><a href="#" class="go-list">목록<span class="blind">목록으로 이동</span></a></li>
+                <!-- // 2022-12-19 수정 끝 -->
                 <li><a href="#" class="next"><span class="blind">다음</span></a></li>
               </ul>
             </div>

--- a/efhiefh2ui344fwe/html/site_map.html
+++ b/efhiefh2ui344fwe/html/site_map.html
@@ -74,7 +74,9 @@
         <section class="site-map">
           <div class="inner">
             <h2 class="motion-tit">
-              <span>Site Map</span>
+              <!-- 2022-12-19 수정 시작 -->
+              <span>SITE MAP</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h2>
             <div class="site-map-wrap">
               <div class="site-map-inn">

--- a/efhiefh2ui344fwe/html/works.html
+++ b/efhiefh2ui344fwe/html/works.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="../pc/css/reset.css">
   <link rel="stylesheet" href="../pc/css/swiper-bundle.min.css"/>
   <link rel="stylesheet" href="../pc/css/common.css">
-  <title>works</title>  
+  <title>WORKS</title>  
   <script src="../pc/js/vendor/jquery-2.1.3.min.js"></script>
   <script src="../pc/js/vendor/gsap.min.js"></script>
   <script src="../pc/js/vendor/ScrollTrigger.min.js"></script>
@@ -75,7 +75,9 @@
           <div class="inner">
             <span class="section1-start"></span>
             <h2 class="motion-tit">
-              <span>Works</span>
+              <!-- 2022-12-19 수정 시작 -->
+              <span>WORKS</span>
+              <!-- // 2022-12-19 수정 끝 -->
             </h2>
             
             <div class="normal-tab-wrap">

--- a/efhiefh2ui344fwe/html/works_view.html
+++ b/efhiefh2ui344fwe/html/works_view.html
@@ -174,7 +174,9 @@
               <div class="contents-pagination">
                 <ul>
                   <li><a href="#" class="prev"><span class="blind">이전</span></a></li>
-                  <li><a href="#" class="go-list">Back to list<span class="blind">목록으로 이동</span></a></li>
+                  <!-- 2022-12-19 수정 시작 -->
+                  <li><a href="#" class="go-list">목록<span class="blind">목록으로 이동</span></a></li>
+                  <!-- // 2022-12-19 수정 끝 -->
                   <li><a href="#" class="next"><span class="blind">다음</span></a></li>
                 </ul>
               </div>

--- a/efhiefh2ui344fwe/pc/css/common.css
+++ b/efhiefh2ui344fwe/pc/css/common.css
@@ -358,12 +358,14 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .contents-pagination ul .next{width: 50px; height: 50px; background: url(../images/common/news_arrow_next.svg) no-repeat center 100%;}
 
 .contents-pagination.type2{margin-top: 80px; text-align: center;}
+/* 2022-12-19 수정 시작 */
 .contents-pagination.type2 a {
     display: block;
-    font-family: 'Poppins', sans-serif;
-    font-size: 50px;
+    /* font-family: 'Poppins', sans-serif; */
+    font-size: 40px;
     color: #555;
 }
+/* // 2022-12-19 수정 끝 */
 
 .tabs ul::after{display: block; content: ''; clear: both; float: inherit;}
 .tabs ul li{float: left; background-color: transparent; border: 0; padding: 0;}
@@ -501,7 +503,9 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .section3.about .sec3-ani-box + .sec3-ani-box{margin-left: 13px;}
 .section3.about .sec3-ani-box.box3{margin-left: 14px;}
 .section3.about .sec3-ani-box .item-num{position: absolute; top: 30px; left: 30px; color: #555; font-family: 'Poppins', sans-serif; font-size: 20px; line-height: 28px}
-.section3.about .sec3-ani-box .item-tit{position: absolute; max-width:100%; top:50%; left:50%; transform: translate(-50%,-50%); color: #fff; font-family: 'Poppins', sans-serif; font-size: 50px; font-weight: 500; text-align: center; letter-spacing: -0.7px; z-index: 10; opacity: 0; transition: opacity 0.4s;}
+/* 2022-12-19 수정 시작 */
+.section3.about .sec3-ani-box .item-tit{position: absolute; max-width:100%; top:50%; left:50%; transform: translate(-50%,-50%); color: #dbfc00; font-family: 'Poppins', sans-serif; font-size: 50px; font-weight: 500; text-align: center; letter-spacing: -0.7px; z-index: 10; opacity: 0; transition: opacity 0.4s;}
+/* // 2022-12-19 수정 끝 */
 .section3.about .sec3-ani-box .item-des{position: absolute; left: 0; right: 0; bottom: 40px; color: #919191; font-size: 16px; line-height: 1.625; text-align: center; letter-spacing: -0.5px; opacity: 0; transition: opacity 0.4s;}
 .section3.about .sec3-ani-box .item-des > strong{color: #fff;}
 .section3.about .sec3-ani-box .item-des > .eng{font-family: 'Poppins', sans-serif;}

--- a/efhiefh2ui344fwe/pc/css/main.css
+++ b/efhiefh2ui344fwe/pc/css/main.css
@@ -214,8 +214,10 @@ h2.tit {color:#fff; font-family:'Poppins', sans-serif; font-size:10rem; font-wei
 .news-cont .btn-view-more {display:block; margin-top:3.6rem; font-family:'Poppins', sans-serif; color:#DBFC00; font-size:1.8rem; line-height:3rem}
 .news-list .list-item.big {width:51%; max-width:76rem}
 .news-list .list-item.big .news-thumb {width:100%; height:52.3rem}
-.news-list .list-item.big .news-thumb::after {content:''; display:block; position:absolute; height:33rem; left:0; right:0; bottom:0; background:linear-gradient(to bottom, transparent, #000); opacity:0; transition:opacity 0.2s}
-.news-list .list-item.big a:hover + .news-thumb::after {content:''; display:block; position:absolute; height:33rem; left:0; right:0; bottom:0; background:linear-gradient(to bottom, transparent, #000); opacity:0.55}
+/* 2022-12-19 수정 시작 */
+.news-list .list-item.big .news-thumb::after {content:''; display:block; position:absolute; height:33rem; left:0; right:0; bottom:0; background:linear-gradient(to bottom, transparent, #000); opacity:0.7; transition:opacity 0.2s}
+.news-list .list-item.big a:hover + .news-thumb::after {content:''; display:block; position:absolute; height:33rem; left:0; right:0; bottom:0; background:linear-gradient(to bottom, transparent, #000);}
+/* // 2022-12-19 수정 끝 */
 .news-list .list-item.big .news-tit {color:#fff; font-size:3.2rem; font-weight:500; line-height:4.4rem; letter-spacing:0}
 .news-list .list-item.big .news-cont {position:absolute; left:0; right:0; bottom:0; padding:4.7rem 5rem}
 .news-list .list-item.big .btn-view-more {margin-top:1.8rem}


### PR DESCRIPTION
1. more → 더 보기로 변경
2. Back to list → 목록으로 변경
3. 각 섹션 타이틀이 대문자로 변경되었습니다.
4. about.html → BRAND IDENTITY → 카드 타이틀의 색상이 #dbfc00색으로 수정되었습니다.
5. common.css가 수정되었습니다.
6. main.html → NEWS news-cont 영역 그림자가 항상 노출되도록 수정되었습니다.

2022-12-19로 검색하시어 수정된 부분을 반영해 주세요.