### PR TITLE
2022-12-19 PC-Front(국문) page_list.html 업데이트

### DIFF
--- a/efhiefh2ui344fwe/page_list.html
+++ b/efhiefh2ui344fwe/page_list.html
@@ -186,7 +186,9 @@
                         <a href="html/main.html" target="_blank">main.html</a><br>
                         <a href="html/gnb.html" target="_blank">gnb.html</a>
                       </td>
-                      <td>2022/11/25</td>
+                      <td>
+                        2022/12/19
+                      </td>
                       <td></td>
                       <td class="etc">
                         [main] 2022/12/01 노트북해상도 추가<br>
@@ -196,7 +198,8 @@
                         [gnb] 2022/12/13 간격수정<br>
                         [main](마크업 수정) 2022/12/14 디저볼래 영상 교체<br>
                         header/footer 일괄 수정<br>
-                        [main, gnb] 2022/12/14 gnb > NEWS 서브메뉴 제거
+                        [main, gnb] 2022/12/14 gnb > NEWS 서브메뉴 제거<br>
+                        [main] 2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -207,14 +210,18 @@
                       <td></td>
                       <td></td>
                       <td><a href="html/main2.html" target="_blank">main2.html</a></td>
-                      <td>2022/11/28</td>
+                      <td>
+                        2022/11/28<br>
+                        2022/12/19
+                      </td>
                       <td></td>
                       <td class="etc">
                         2022/12/01 노트북해상도 추가<br>
                         2022/12/05(마크업 수정) 구글시트 요청(1820215024) 업데이트<br>
                         2022/12/13 Partners 슬라이드 수정<br>
                         2022/12/14 footer 사이트맵링크 추가<br>
-                        2022/12/14 gnb > NEWS 서브메뉴 제거
+                        2022/12/14 gnb > NEWS 서브메뉴 제거<br>
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -225,8 +232,8 @@
                       <td></td>
                       <td></td>
                       <td><a href="html/about.html" target="_blank">about.html</a></td>
-                      <td>2022/12/16</td>
-                      <td>검수요청</td>
+                      <td>2022/12/19</td>
+                      <td></td>
                       <td class="etc">
                         2022/12/14 수정<br />
                         <br />
@@ -243,6 +250,11 @@
                           <li>+ 로고 박스 외부 테두리, 내부 배경 색상이 변경되었습니다.</li>
                           <li>+ BI 다운로드 텍스트로 변경되었습니다.</li>
                         </ul>
+
+                        <strong>2022/12/19</strong>
+                        <ul>
+                          <li>+ BRAND IDENTITY → 카드 타이틀의 색상이 #dbfc00색으로 수정</li>
+                        </ul>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -253,9 +265,12 @@
                       <td></td>
                       <td></td>
                       <td><a href="html/partners.html" target="_blank">partners.html</a></td>
-                      <td>2022/12/01</td>
+                      <td>2022/12/19</td>
                       <td></td>
-                      <td class="etc"></td>
+                      <td class="etc">
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
+                        2022/12/19 more를 더보기로 변경<br>
+                      </td>
                     </tr>
                     <!-- <tr>
                       <th scope="row" class="col-num"></th>
@@ -289,7 +304,7 @@
                       <td></td>
                       <td></td>
                       <td><a href="html/works.html" target="_blank">works.html</a></td>
-                      <td>2022/11/23</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
                         2022/11/25 hover 상세 디자인 변경<br>
@@ -297,7 +312,8 @@
                         2022/12/01 디자인컨펌버전 업데이트<br>
                         2022/12/02 공식 웹사이트 피드백 이미지 hover 애니메이션/스타일 수정<br>
                         2022/12/13 hover 상세 디자인 변경 및 마크업 수정<br>
-                        2022/12/14 콘텐츠내용 및 이미지 변경 2022.12.14 콘텐츠 내용 변경(주석처리)
+                        2022/12/14 콘텐츠내용 및 이미지 변경 2022.12.14 콘텐츠 내용 변경(주석처리)<br>
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -308,14 +324,15 @@
                       <td></td>
                       <td></td>
                       <td><a href="html/works_view.html" target="_blank">works_view.html</a></td>
-                      <td>2022/11/23</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
                         2022/12/01 디자인컨펌버전 업데이트<br>
                         2022/12/05 공식 웹사이트 피드백 이미지 스왑 애니메이션 수정
                         2022/12/08 수정부분 22.12.08 날짜로 주석처리, 이미지삭제(1개의 이미지로 확정)<br>
                         2022/12/14 폰트사이즈 수정(css수정)<br>
-                        2022/12/14 콘텐츠내용 및 이미지 변경 2022.12.14 콘텐츠 내용 변경(주석처리)
+                        2022/12/14 콘텐츠내용 및 이미지 변경 2022.12.14 콘텐츠 내용 변경(주석처리)<br>
+                        2022/12/19 Back to list → 목록으로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -326,11 +343,12 @@
                       <td>리스트</td>
                       <td></td>
                       <td><a href="html/news_list.html" target="_blank">news_list.html</a></td>
-                      <td>2022/11/22</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
                         2022/12/06 구글시트 요청(625913885) 업데이트<br>
-                        2022/12/13 search-box > placeholder > font-weight 수정(공통)
+                        2022/12/13 search-box > placeholder > font-weight 수정(공통)<br>
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -341,13 +359,15 @@
                       <td>상세</td>
                       <td></td>
                       <td><a href="html/news_contents.html" target="_blank">news_contents.html</a></td>
-                      <td>2022/11/22</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
                         <!-- 개발 전달 후 수정 일 경우 기입 -->
                         <!-- 2022/11/23 내용수정 -->
                         2022/12/01 디자인컨펌버전 업데이트<br>
                         2022/12/06 구글시트 요청(625913885) 업데이트<br>
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
+                        2022/12/19 이미지 슬라이드 하단 설명 영역이 추가
                       </td>
                     </tr>
                     
@@ -359,11 +379,12 @@
                       <td></td>
                       <td></td>
                       <td><a href="html/contact_us.html" target="_blank">contact_us.html</a></td>
-                      <td>2022/11/23</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
                         2022/12/06 구글시트 요청(625913885) 업데이트<br>
-                        2022/12/09 타이틀 텍스트 수정(contact us -> contact)
+                        2022/12/09 타이틀 텍스트 수정(contact us -> contact)<br>
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -374,12 +395,13 @@
                       <td>리스트</td>
                       <td></td>
                       <td><a href="html/recruitment.html" target="_blank">recruitment.html</a></td>
-                      <td>2022/11/23</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
                         2022/12/06 구글시트 요청(625913885) 업데이트<br>
                         2022/12/13 공지 이미지 변경<br>
-                        2022/12/14 리스트 갯수 2개 추가 총 보이는 리스트 10개
+                        2022/12/14 리스트 갯수 2개 추가 총 보이는 리스트 10개<br>
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -390,14 +412,16 @@
                       <td>상세</td>
                       <td></td>
                       <td><a href="html/recruitment_contents.html" target="_blank">recruitment_contents.html</a></td>
-                      <td>2022/11/23</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
                         2022/12/01 디자인컨펌버전 업데이트<br>
                         2022/12/06 구글시트 요청(625913885) 업데이트<br>
                         2022/12/09 지원하기 샘플내용 삭제<br>
                         2022/12/14 이미지변경 이미지랑 텍스트부분 분리(2022.12.14 주석처리)<br>
-                        2022/12/14 수정내용 2022.12.14 로 주석처리
+                        2022/12/14 수정내용 2022.12.14 로 주석처리<br>
+                        2022/12/19 각 섹션 타이틀이 대문자로 변경<br>
+                        2022/12/19 Back to list → 목록으로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">
@@ -456,10 +480,10 @@
                       <td></td>
                       <td></td>
                       <td><a href="html/site_map.html" target="_blank">site_map.html</a></td>
-                      <td>2022/12/08</td>
+                      <td>2022/12/19</td>
                       <td></td>
                       <td class="etc">
-                        
+                        2022/12/19 각 섹션 타이틀 및 메뉴명이 대문자로 변경<br>
                       </td>
                     </tr>
                     <tr class="row-done">


### PR DESCRIPTION
1. more → 더 보기로 변경
2. Back to list → 목록으로 변경
3. 각 섹션 타이틀이 대문자로 변경되었습니다.
4. about.html → BRAND IDENTITY → 카드 타이틀의 색상이 #dbfc00색으로 수정되었습니다.
5. common.css가 수정되었습니다.
6. main.html → NEWS news-cont 영역 그림자가 항상 노출되도록 수정되었습니다.
7. partners.html에 드림팩토리 스튜디오 로고(partner_log13.png) 이미지가 추가되었습니다.
8. recruitment.html colgroup 첫번째 col width값이 수정되었습니다.
9. recruitment.html, recruitment_contents.html 공지(ico-notice.png) 이미지의 크기가 수정되어 이미지가 교체되었습니다.
10. news_contents.html 이미지 슬라이드 하단 설명 영역이 추가되었습니다.

2022-12-19로 검색하시어 수정된 부분을 반영해 주세요.