### PR TITLE
(2022-12-21) MO-Front(국문) 여백, 폰트, 레이아웃 수정

### DIFF
--- a/efhiefh2ui344fwe/html_m/about.html
+++ b/efhiefh2ui344fwe/html_m/about.html
@@ -59,12 +59,14 @@
             <div class="section1-inner">
               <div class="bg"></div>
               <div class="sec1-txt-area">
+                <!-- 2022-12-21 수정 시작 -->
                 <p class="txt1 effect">
-                  STUDIO X+U는<br>
+                  <span class="eng">STUDIO X+U</span>는<br>
                   새로운 콘텐츠 창작으로<br>
                   고객에게 차별화된<br>
                   즐거움과 경험을 선사합니다
                 </p>
+                <!-- // 2022-12-21 수정 끝 -->
 
                 <p class="txt2 effect">
                   재미있고(Fun), 누구나 공감 가고 (Empathetic), 혁신적이며(Innovative), 확장 가능한(Scalable)<br>
@@ -89,7 +91,9 @@
                   새로운 콘텐츠 경험을 선보이기 위해 <br>
                   STUDIO X+U는 고객들의 콘텐츠 경험 안에서 추구하는 <br>
                   새로운 <strong class="icon-x">X</strong>를 계속해서 찾아가고 있습니다<br>
-                  <br>
+                  <!-- 2022-12-21 수정 시작 -->
+                  <!-- <br> -->
+                  <!-- // 2022-12-21 수정 끝 -->
                   즐거움을 배가하고 새로움을 더하다
                 </p>
 

--- a/efhiefh2ui344fwe/html_m/main2.html
+++ b/efhiefh2ui344fwe/html_m/main2.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="../mobile/css/jquery.fullPage.css">
   <link rel="stylesheet" href="../mobile/css/swiper-bundle.min.css">
   <link rel="stylesheet" href="../mobile/css/main2.css">
-  <title>메인 2차</title>
+  <title>메인 2차 오픈</title>
   <script src="../mobile/js/vendor/jquery-2.1.3.min.js"></script>
   <script src="../mobile/js/vendor/scrolloverflow.min.js"></script>
   <script src="../mobile/js/vendor/jquery.fullPage.js"></script>
@@ -122,7 +122,9 @@
 
               <div class="sec-txt-area">
                 <a href="#"></a>
-                <p class="sec-txt">STUDIO X+U는 새로운 콘텐츠 창작으로<br> 고객에게 차별화된 즐거움과 경험을 선사합니다</p>
+                <!-- 2022-12-21 수정 시작 -->
+                <p class="sec-txt"><span class="eng">STUDIO X+U</span>는 새로운 콘텐츠 창작으로<br> 고객에게 차별화된 즐거움과 경험을 선사합니다</p>
+                <!-- // 2022-12-21 수정 끝 -->
                 <div class="sec-tit-wrap">
                   <span class="sec-tit">Find X,<br> Studio X+U</span>
                   <span class="view-more">view<br>more</span>

--- a/efhiefh2ui344fwe/html_m/works.html
+++ b/efhiefh2ui344fwe/html_m/works.html
@@ -23,6 +23,7 @@
 
 <body>
   <div class="wrap">
+
     <!-- header -->
     <!-- 서브용 임시 해더 -->
     <header id="header" class="main-tool-bar">
@@ -126,7 +127,9 @@
             </div>
           </div>
 
-          <div class="pagination-wrap mt0">
+          <!-- 2022-12-21 수정 시작 -->
+          <!-- [D] <div class="pagination-wrap mt0">에서 mt0 가 삭제되었습니다. -->
+          <div class="pagination-wrap">
             <div class="pagination">
               <!-- <a href="#">&laquo;</a> -->
               <a class="active" href="#">1</a>
@@ -137,6 +140,7 @@
               <!-- <a href="#">&raquo;</a> -->
             </div>
           </div>
+          <!-- // 2022-12-21 수정 끝 -->
 
         </div>
       </div>

--- a/efhiefh2ui344fwe/mobile/css/common.css
+++ b/efhiefh2ui344fwe/mobile/css/common.css
@@ -62,15 +62,22 @@ body{background-color: #000;}
 /* header */
 #header {position:fixed; top:0; left:0; right:0; z-index:1000; background-color: #000;}
 #header .header-inner {position: relative;display:flex; justify-content: space-between; width:100%; margin:0 auto; padding:20px 0}
-#header .logo {margin:0;margin-left: 20px;}
+/* 2022-12-21 수정 시작 */
+#header .logo {margin:0;margin-left: 21px;}
+/* // 2022-12-21 수정 끝 */
 #header .logo a {display:inline-block; width:127px; height: 18px;}
 
-#header .all-menu{margin-right: 20px; width: 21px; height: 21px; background: url(../images/common/menu.png) no-repeat 0 50%; background-size: contain; -webkit-transition: all 0.35s ease;transition: all 0.35s ease;}
+/* 2022-12-21 수정 시작 */
+#header .all-menu{margin-right: 25px; width: 21px; height: 21px; background: url(../images/common/menu.png) no-repeat 0 50%; background-size: contain; -webkit-transition: all 0.35s ease;transition: all 0.35s ease;}
+/* // 2022-12-21 수정 끝 */
 #header .all-menu.on{background: url(../images/common/menu_on.png) no-repeat 0 0; background-size: contain; -webkit-transition: all 0.35s ease;transition: all 0.35s ease;}
 
 .gnb {padding-bottom: 40px;}
 .gnb .gnb-list {}
-.gnb .gnb-list > li {}
+/* 2021-12-21 수정 시작 */
+.gnb .gnb-list > li {margin-top:2px;}
+.gnb .gnb-list > li:first-child {margin-top:0;}
+/* // 2021-12-21 수정 끝 */
 .gnb .gnb-list > li > a {position: relative; display: block; padding-top: 10px; padding-bottom: 10px; font-family: 'Poppins', sans-serif; font-size:30px; line-height:40px; color: #fff; font-weight: bold; text-align: center;}
 /* .gnb .gnb-list > li > a:after {content: ""; position: absolute; right: 2px; top: 36px; width: 19px;;height: 11px;background: url(../images/common/ico_down.png) no-repeat 0 0; background-size: cover; -webkit-transition: all 0.35s ease;transition: all 0.35s ease;} */
 .gnb .gnb-list > li > a.nm:after {display: none;}
@@ -78,9 +85,13 @@ body{background-color: #000;}
 .gnb .gnb-list > li > a.active:after {transform: rotate( 180deg )}
 
 .gnb .gnb-list .sub-list {display: none; padding-bottom: 20px;}
-.gnb .gnb-list .active+.sub-list {margin-top: 10px;}
+/* 2021-12-21 수정 시작 */
+.gnb .gnb-list .active+.sub-list {margin-top: 21px;}
+/* // 2021-12-21 수정 끝 */
 .gnb .gnb-list .sub-list a{margin-top: 4px; display: block; font-family: 'Poppins', sans-serif; font-size: 30px; color: #555; text-align: center;}
-.gnb .gnb-list .sub-list li+li{margin-top: 14px;}
+/* 2021-12-21 수정 시작 */
+.gnb .gnb-list .sub-list li+li{margin-top: 22px;}
+/* // 2021-12-21 수정 끝 */
 
 #header.main-tool-bar.active{transition: ease 0.4s; background: #000;}
 #header.main-tool-bar.active .sub-list {}
@@ -117,7 +128,9 @@ body{background-color: #000;}
 .sns-link a{display: inline-block;width: 40px; height: 40px;}
 
 /* contents */
-.inner {padding-top: 94px; position: relative; margin: 0 auto;}
+/* 2022-12-21 수정 시작 */
+.inner {padding-top: 90px; position: relative; margin: 0 auto;}
+/* // 2022-12-21 수정 끝 */
 /* .inner {max-width: 360px;} */
 .inner.no-padding {padding-top: 0;}
 /* .inner.type2 {padding-top: 136px;} */
@@ -127,7 +140,9 @@ section{position: relative;}
 /* 2022-12-20 v2 수정 시작 */
 .motion-tit > span{display: block; font-family: 'Poppins', sans-serif; font-size: 56px; line-height: 80px; color: #fff; transform-origin: 50% 50%; transform: translate(0%, 130%) skew(-10deg, 0deg) scale(1, 1.5); animation:skewUp 0.8s forwards}
 /* 2022-12-20 v2 수정 끝 */
-
+/* 2022-12-21 수정 시작 */
+.motion-tit ~ .normal-tab-wrap {margin-top: -6px;}
+/* // 2022-12-21 수정 끝 */
 .overflow-h{overflow: hidden;}
 .normal-tab-wrap .normal-tab{position: relative; overflow: hidden; overflow-x: auto; -ms-overflow-style: none; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
 .normal-tab-wrap .normal-tab::-webkit-scrollbar{display:none;}
@@ -190,10 +205,14 @@ section{position: relative;}
 /* .notice-top .notice-top-num{} */
 /* .notice-top .notice-top-sch{} */
 
-.pagination-wrap{overflow: hidden;text-align: center;margin-top:40px;margin-bottom:40px;font-family: 'Poppins', sans-serif;}
+/* 2021-12-21 수정 시작 */
+.pagination-wrap{overflow: hidden;text-align: center;margin-top:46px;margin-bottom:81px;font-family: 'Poppins', sans-serif;}
+/* // 2021-12-21 수정 끝 */
 .pagination {display: inline-block;}
 .pagination a {color: #fff;float: left;padding: 0 10px;text-decoration: none; font-size: 28px; opacity: 0.3;}
-.pagination a:nth-child(n+2){margin-left: 10px;}
+/* 2021-12-21 수정 시작 */
+.pagination a:nth-child(n+2){margin-left: 14px;}
+/* // 2021-12-21 수정 끝 */
 .pagination a.active {color: white; opacity: 1;}
 .pagination.small-type {border: 1px solid #ccc!important;}
 .pagination.small-type li {display: inline;}
@@ -257,7 +276,9 @@ select::-ms-expand {display: none;}
 a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1px solid #ddd;background-color: #ddd;font-size: 13px;color: #000;line-height: 25px;}
 
 #allMenu.pop-layer{height: calc(100% - 58px); background-color: #000; border:none; overflow-y: auto;}
-#allMenu .pop-container{padding: 40px 20px;}
+/* 2022-12-21 수정 시작 */
+#allMenu .pop-container{padding: 64px 20px 40px; }
+/* // 2022-12-21 수정 끝 */
 /* List */
 .list-ul-1{margin-left: 20px;list-style: disc;}
 .list-ul-1 li+li{margin-top:4px;}
@@ -282,38 +303,56 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .tabs li a {padding: 20px;font-size: 14px;color: #222;display: block;height: 100%;/* vertical-align: middle; */text-decoration: none;color: #000}
 .news-list-wrap{padding: 0 20px; opacity: 0; animation: fadeIn 0.4s ease-in-out forwards; animation-delay: 1s;}
 .news-list-wrap .normal-list ul{display: flex; flex-direction: column;}
-.news-list-wrap .normal-list ul li{margin-bottom: 60px; flex: 0 0 auto; width: 100%; box-sizing: border-box;}
+/* 2022-12-21 수정 시작 */
+.news-list-wrap .normal-list ul li{margin-bottom: 42px; flex: 0 0 auto; width: 100%; box-sizing: border-box;}
+/* // 2022-12-21 수정 끝 */
 .news-list-wrap .normal-list ul li .anchor-box{position: relative;}
 .news-list-wrap .normal-list ul li .anchor-box a{position: absolute; width: 100%; height: 100%;}
-.news-list-wrap .normal-list ul li .news-img{margin-bottom: 40px;}
+/* 2022-12-21 수정 시작 */
+.news-list-wrap .normal-list ul li .news-img{margin-bottom: 32px;}
+/* // 2022-12-21 수정 끝 */
 .news-list-wrap .normal-list ul li .news-img img{display: block; width: 100%;}
 .news-list-wrap .normal-list ul li .news-title{font-size: 20px; line-height: 30px; color: #FFFFFF; font-weight: 600; letter-spacing: -1px; word-break:keep-all; word-wrap: break-word;}
 .news-list-wrap .normal-list ul li .news-title span{font-weight: 600; word-break:keep-all; word-wrap: break-word;}
-.news-list-wrap .normal-list ul li .news-sub{display: block; font-size: 14px; line-height: 24px; color: #919191; margin: 11px 0 21px; text-overflow: ellipsis; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; word-break:keep-all; word-wrap: break-word; letter-spacing: -1px;}
+/* 2022-12-21 수정 시작 */
+.news-list-wrap .normal-list ul li .news-sub{display: block; font-size: 14px; line-height: 24px; color: #919191; margin: 13px 0 21px; text-overflow: ellipsis; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; word-break:keep-all; word-wrap: break-word; letter-spacing: -1px;}
+/* // 2022-12-21 수정 끝 */
 .news-list-wrap .normal-list ul li .view-more{font-family: 'Poppins', sans-serif; font-size:12px; color: #DBFC00; }
 .more-btn-box{text-align: center; margin-bottom: 150px;}
 .more-btn-box button{font-family: 'Poppins', sans-serif; font-size:50px; color: #555; background-color: transparent;}
 /* search-wrap */
 .blind {position: absolute; clip: rect(0 0 0 0); width: 1px; height: 1px; margin: -1px; overflow: hidden;}
-.search-wrap{display: flex; margin-bottom: 30px; justify-content: space-between; padding: 0 20px; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
+/* 2022-12-21 수정 시작 */
+.search-wrap{display: flex; margin-bottom: 40px; justify-content: space-between; padding: 21px 20px 0; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
+/* // 2022-12-21 수정 끝 */
 .search-wrap .search-box{display: flex; justify-content: center; align-items: center; width: 100%;}
 .search-wrap .search-box .unit-box{border-bottom: 2px solid #fff; position: relative; width: 22%; min-width: 80px;}
 .search-wrap .search-box .unit-box.full{width: 100%;}
 .search-wrap .search-box .unit-box+.unit-box{margin-left: 20px; width: 100%;}
-.search-wrap .search-box .unit-box select{padding: 7px 0 7px; top: 0; border: 0; width: 100%; color: #fff; font-weight: 600; font-size: 14px; background-size: auto; background-image: url(../images/common/down_arrow_select.svg); background-position: right center;}
-.search-wrap .search-box .unit-box [type="search"]{padding: 9px 24px 11px 0; border-radius: 0; border: 0; background-color: transparent; width: 100%; color: #fff; font-size: 14px; letter-spacing: -1px;}
+/* 2022-12-21 수정 시작 */
+.search-wrap .search-box .unit-box select{height: 38px;padding: 7px 0 7px; top: 0; border: 0; width: 100%; color: #fff; font-weight: 600; font-size: 14px; background-size: auto; background-image: url(../images/common/down_arrow_select.svg); background-position: right center;}
+.search-wrap .search-box .unit-box [type="search"]{height: 38px;padding: 9px 24px 11px 0; border-radius: 0; border: 0; background-color: transparent; width: 100%; color: #fff; font-size: 14px; letter-spacing: -1px;}
+/* // 2022-12-21 수정 끝 */
 .search-wrap .search-box .unit-box [type="search"]::placeholder{font-weight: 100; color: #555;}
-.search-wrap .search-box .unit-box .search-btn{position: absolute; right: 0; top: 10px; border: 0; width: 24px; height: 24px; background-image: url(../images/common/search_btn.svg); background-color: transparent; background-repeat: no-repeat; background-position: center;}
+/* 2022-12-21 수정 시작 */
+.search-wrap .search-box .unit-box .search-btn{position: absolute; right: 0; top: 5px; border: 0; width: 24px; height: 24px; background-image: url(../images/common/search_btn.svg); background-color: transparent; background-repeat: no-repeat; background-position: center;}
+/* // 2022-12-21 수정 끝 */
 .search-wrap .search-box .unit-box [type="search"]::-ms-clear,
 .search-wrap .search-box .unit-box [type="search"]::-ms-reveal{display: none;}
 .search-wrap .search-box .unit-box [type="search"]::-webkit-search-decoration,
 .search-wrap .search-box .unit-box [type="search"]::-webkit-search-cancel-button,
 .search-wrap .search-box .unit-box [type="search"]::-webkit-search-results-button,
 .search-wrap .search-box .unit-box [type="search"]::-webkit-search-results-decoration {display: none;}
-
-.news-contents-wrap{margin-top: 50px; padding: 0 20px;}
-.news-title-wrap{position: relative; padding: 26px 0 28px; border-top: 1px solid #444444; border-bottom: 1px solid #444444; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
-.news-title-wrap h4{overflow: hidden;display: -webkit-box;font-size: 20px; font-weight: 600; color: #fff; margin: 0; line-height: 35px;-webkit-line-clamp: 4;-webkit-box-orient: vertical;text-overflow: ellipsis;}
+/* 2022-12-21 수정 시작 */
+.news-contents-wrap{margin-top: 35px; padding: 0 20px;}
+/* // 2022-12-21 수정 끝 */
+/* 2022-12-21 추가 시작 */
+.news-contents-wrap ~ .contents-pagination {margin-right: 20px;margin-left: 20px}
+/* // 2022-12-21 추가 끝 */
+.news-title-wrap{position: relative; padding: 24px 0 26px; border-top: 1px solid #444444; border-bottom: 1px solid #444444; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
+/* 2022-12-21 수정 시작 */
+.news-title-wrap h4{overflow: hidden;display: -webkit-box;font-size: 20px; font-weight: 600; color: #fff; margin: 0; line-height: 1.6;-webkit-line-clamp: 4;-webkit-box-orient: vertical;text-overflow: ellipsis;}
+/* // 2022-12-21 수정 끝 */
 .news-title-wrap p.date{margin-top: 8px; color: #919191; font-size: 12px;}
 .ver-recruit .news-title-wrap {padding: 25px 0 26px;}
 .ver-recruit .news-title-wrap h4{font-size: 20px; line-height: 35px; letter-spacing: 0; word-break: keep-all;  word-wrap: break-word;line-height:1.2222}
@@ -323,11 +362,15 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .ver-recruit .inner-news-title-wrap {padding-left: 56px;}
 .ver-recruit .news-title-wrap .notice {color:#000;font-size:0.625rem;background-color: #dbfc00;width:40px;height:40px;border-radius:100%;font-weight:500;text-align:center;line-height:40px;position:absolute;top:50%;left:0;z-index:1;transform: translateY(-50%)}
 
-.news-contents-box{padding: 40px 0; border-bottom: 1px solid #444444; font-size: 14px; color: #fff; letter-spacing: -1px; line-height: 24px; opacity: 0; animation: fadeIn 0.4s ease-in-out forwards; animation-delay: 1s;}
+/* 2022-12-21 수정 시작 */
+.news-contents-box{padding: 24px 0 47px; border-bottom: 1px solid #444444; font-size: 14px; color: #fff; letter-spacing: -1px; line-height: 24px; opacity: 0; animation: fadeIn 0.4s ease-in-out forwards; animation-delay: 1s;}
+/* // 2022-12-21 수정 끝 */
 .news-contents-box a {color: #fff;}
 .contents-img{margin-bottom: 36px;}
 .contents-img img{width: 100%;}
-.contents-pagination{margin: 40px 0 80px; padding: 0 20px;}
+/* 2022-12-21 수정 시작 */
+.contents-pagination{margin: 40px 0 80px; padding: 0;}
+/* // 2022-12-21 수정 끝 */
 .contents-pagination.right {width: calc(50% - 50px); margin-left: auto;}
 .contents-pagination ul{display: flex; justify-content: space-between;}
 .contents-pagination ul a{display: block; font-family: 'Poppins', sans-serif; font-size: 24px; color: #555;}
@@ -342,20 +385,28 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
     color: #555;
 }
 
-.information{margin-top: 35px; padding: 0 20px; letter-spacing: -1px; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
+/* 2022-12-21 수정 시작 */
+.information{margin-top: 37px; padding: 0 20px; letter-spacing: -1px; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
+/* // 2022-12-21 수정 끝 */
 .information+.information{margin-top: 44px;}
 .information dl{display: table;}
-.information dl:nth-child(n+2){margin-top: 12px;}
+/* 2022-12-21 수정 시작 */
+.information dl:nth-child(n+2){margin-top: 15px;}
+/* // 2022-12-21 수정 끝 */
 .information dt,
 .information dd{display: table-cell;}
-.information dt{font-size: 16px; font-family: 'Poppins', sans-serif; color: #fff; width: 25%; min-width: 90px;  letter-spacing: 0px;}
+/* 2022-12-21 수정 시작 */
+.information dt{font-size: 16px; font-family: 'Poppins', sans-serif; color: #fff; width: 25%; min-width: 82px;  letter-spacing: 0px;}
+/* // 2022-12-21 수정 끝 */
 .information dt strong{font-weight: bold;}
 .information dd{font-size: 14px; color: #919191; line-height: 24px;}
 .information dd a{color: #919191;}
 .information dd li:nth-child(n+2){margin-top: 2px;}
 .information .tel,
 .information .email{font-family: 'Poppins', sans-serif;}
-.maps-wrap{width: 100%; height:600px; background-color: gray; margin-top: 56px; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
+/* 2022-12-21 수정 시작 */
+.maps-wrap{width: 100%; height:600px; background-color: gray; margin-top: 32px; opacity: 0; animation: fadeIn 0.2s ease-in-out forwards; animation-delay: 0.8s;}
+/* // 2022-12-21 수정 끝 */
 
 .list-type-table{padding:0 20px; opacity: 0; animation: fadeIn 0.4s ease-in-out forwards; animation-delay: 1s;}
 .list-type-table table{table-layout: fixed;    width: 100%; vertical-align: middle;}
@@ -381,16 +432,23 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 /* works - list */
 .works .normal-tab-wrap{margin-top: -5px;}
 .works-list-wrap{position: relative; margin-top: 40px; opacity: 0; animation: fadeIn 0.4s ease-in-out forwards; animation-delay: 1s;}
+/* 2022-12-21 추가 시작 */
+/* .works-list-wrap ~ .pagination-wrap {margin: 46px 0 81px} */
+/* // 2022-12-21 추가 끝 */
 .works-list-wrap .normal-list{padding: 0 20px;}
 .works-list-wrap .normal-list > ul{display: flex; flex-wrap: wrap; flex: 0 0 auto;}
-.works-list-wrap .normal-list > ul > li{margin-bottom: 60px; flex: 0 0 auto; width: 100%; box-sizing: border-box;}
+/* 2022-12-21 수정 시작 */
+.works-list-wrap .normal-list > ul > li{margin-bottom: 42px; flex: 0 0 auto; width: 100%; box-sizing: border-box;}
+/* // 2022-12-21 수정 끝 */
 .works-list-wrap .normal-list ul li.bigger{flex: 0 0 auto; width: 66.666%;}
 .works-list-wrap .normal-list .anchor-box{position: relative;}
 .works-list-wrap .normal-list .anchor-box a{position: absolute; width: 100%; height: 100%; z-index: 1;}
 .works-list-wrap .normal-list .works-img{position: relative; margin-bottom: 25px;}
 .works-list-wrap .normal-list .works-img img{display: block; width: 100%;}
 .works-list-wrap .normal-list .works-title{font-size: 20px; line-height: 44px; color: #FFFFFF;}
-.works-list-wrap .normal-list .works-sub{display: block; font-size: 16px; line-height: 22px; color: #919191; margin: 11px 0 21px; letter-spacing: -0.8px; text-overflow: ellipsis; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2;}
+/* 2022-12-21 수정 시작 */
+.works-list-wrap .normal-list .works-sub{display: block; font-size: 14px; line-height: 22px; color: #919191; margin: 0 0 22px; letter-spacing: -0.8px; text-overflow: ellipsis; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2;}
+/* // 2022-12-21 수정 끝 */
 .works-list-wrap .normal-list .view-more{font-family: 'Poppins', sans-serif; font-size:12px; color: #DBFC00; }
 .works-img .img-hover-box {display: none;}
 .anchor-box:hover .img-hover-box{display:block; position: absolute; left: 0; right: 0; top: 0; bottom: 0; display: flex; align-items: center; padding: 0 60px; background-color: rgba(0,0,0,0.7);}
@@ -403,47 +461,67 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .section1.works-view{min-height: 0; padding-top: 0;}
 .works-view-wrap{margin-top: 80px; padding: 0 20px;}
 .works-view-wrap .view-tag{display: flex;}
-.works-view-wrap .view-tag .tag{display: block; padding: 0 11px; border: 1px solid #919191; border-radius: 30px; color: #919191; font-family: 'Poppins', sans-serif; font-size:12px; line-height: 18px;}
+/* 2022-12-21 수정 시작 */
+.works-view-wrap .view-tag .tag{display: block; padding: 0 7px; border: 1px solid #919191; border-radius: 30px; color: #919191; font-family: 'Poppins', sans-serif; font-size:12px; line-height: 18px;text-transform: uppercase;}
+/* // 2022-12-21 수정 끝 */
 .works-view-wrap .view-tag .tag + .tag{margin-left: 8px;}
-.works-view-wrap .view-title{overflow: hidden;display: -webkit-box;   margin-top: 26px; color: #fff; font-size: 44px; font-weight: 500;   text-overflow: ellipsis;-webkit-line-clamp: 2;-webkit-box-orient: vertical;}
-.works-view-wrap .view-sub{margin-top: 10px; color: #919191; font-size: 14px; line-height: 24px;}
-.works-view-wrap .view-cont{padding-top: 50px;}
+/* 2022-12-21 수정 시작 */
+.works-view-wrap .view-title{overflow: hidden;display: -webkit-box;   margin-top: 42px; color: #fff; font-size: 44px; font-weight: 500;   text-overflow: ellipsis;-webkit-line-clamp: 2;-webkit-box-orient: vertical;}
+.works-view-wrap .view-sub{margin-top: 24px; color: #919191; font-size: 14px; line-height: 24px;}
+.works-view-wrap .view-cont{padding-top: 39px;}
+/* // 2022-12-21 수정 끝 */
 .works-view-right .view-cont{padding-top: 100px;}
 .works-view-wrap .cont-info-list{border-top: 1px solid #444; border-bottom: 1px solid #444;}
-.works-view-wrap .cont-info-list > li{/* display: flex; */padding: 18px 0 30px;}
+/* 2022-12-21 수정 시작 */
+.works-view-wrap .cont-info-list > li{/* display: flex; */padding: 18px 0 35px;}
+/* // 2022-12-21 수정 끝 */
 .works-view-wrap .cont-info-list > li + li{border-top: 1px solid #444;}
 .works-view-wrap .cont-info-list .list-tit{/* min-width: 108px; */display:block;color: #919191; font-size: 14px; letter-spacing: -0.6px;}
-.works-view-wrap .cont-info-list .list-txt{display:block;margin-top:10px;color: #fff; font-size: 14px;letter-spacing: -0.6px;}
-
+/* 2022-12-21 수정 시작 */
+.works-view-wrap .cont-info-list .list-txt{display:block;margin-top:15px;color: #fff; font-size: 14px;letter-spacing: -0.6px;}
+/* // 2022-12-21 수정 끝 */
 .works-view-wrap .view-cont .cont-img{width: 100%;}
 .works-view-wrap .view-cont .cont-img > img{display:block; width: 100%;}
 .works-view-wrap .view-cont .cont-img > img + img{margin-top: 24px;}
 
 .works-view-wrap .contents-youtube {position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin-top: 24px;}
 .works-view-wrap .contents-youtube iframe {position: absolute; top: 0; left: 0; width: 100%; height: 100%;}
-.works-view-wrap .contents-pagination:before {content: ""; display: block; margin-bottom: 24px; border-top: 1px solid #444;}
-
+/* 2022-12-21 수정 시작 */
+.works-view-wrap .contents-pagination:before {content: ""; display: block; margin-bottom: 27px; border-top: 1px solid #444;}
+/* // 2022-12-21 수정  끝 */
 
 /* about */
 .about h3.tit{margin: 0; color: #fff; font-family: 'Poppins', sans-serif; font-size: 50px; font-weight: normal; line-height: 70px}
-.section1.about{margin-top: 40px; padding: 0 20px;}
+/* 2022-12-21 수정 시작 */
+.section1.about{margin-top: 36px; padding: 0 20px;}
+/* // 2022-12-21 수정 끝 */
 .section1.about .section1-inner{padding-bottom: 245px;}
 .section1.about .sec1-txt-area .txt1{display: block; color: #fff; font-size: 28px; font-weight: 500; line-height: 44px;}
-.section1.about .sec1-txt-area .txt2{display: inline-block; padding-top: 24px; color: #919191; font-size: 14px; line-height: 26px; text-align: left; letter-spacing: -0.8px;}
+/* 2022-12-21 수정 시작 */
+.section1.about .sec1-txt-area .txt1 > .eng{font-family: 'Poppins', sans-serif;}
+.section1.about .sec1-txt-area .txt2{display: inline-block; padding-top: 17px; color: #919191; font-size: 14px; line-height: 1.8571; text-align: left; letter-spacing: -0.8px;}
+/* // 2022-12-21 수정 끝 */
 .section1.about .bg{position: absolute; width: 100%; height: 204px; max-height: 100%; left: 0; right: 0; bottom: 0; background: url(../images/sub/img-about-bg.png) no-repeat center / 100% auto;}
 .section1.about .bg::before {content: ''; display: block; position: absolute; width: 100%; height: 100%; top: 0; left: 0; right: 0; bottom: 0; background-image: linear-gradient(to bottom, rgba(0,0,0,1) 15%, rgba(0,0,0,0.4) 30%, rgba(0,0,0,0.4) 80%, rgba(0,0,0,1) 90%);}
 
 .section2.about{margin-top: -195px; padding: 0 20px;}
+/* 2022-12-21 추가 시작 */
+.section2.about .inner {padding-top: 121px;}
+/* // 2022-12-21 추가 끝 */
 /* 2022-12-20 v2 수정 시작 */
 .section2.about .sec2-txt-area .txt1{display: flex; padding-left: 0; color: #fff; font-size: 28px; font-weight: 500; line-height: 86px;}
 /* // 2022-12-20 v2 수정 끝 */
 .section2.about .sec2-txt-area .txt1 .icon-x{display: inline-block; width: 32.8px; height: 67.5px; margin-left: 10px; background: url(../images/sub/icon-x.svg) no-repeat center / contain; font-size: 0; text-indent: -9999%; overflow: hidden;}
-.section2.about .sec2-txt-area .txt2{margin-top: 20px; color: #919191; font-size: 14px; font-weight: 500; line-height: 26px; text-align: left; letter-spacing: -1px;}
+/* 2022-12-21 수정 시작 */
+.section2.about .sec2-txt-area .txt2{margin-top: -3px; color: #919191; font-size: 14px; font-weight: 500; line-height: 26px; text-align: left; letter-spacing: -1px;}
+/* // 2022-12-21 수정 끝 */
 .section2.about .sec2-txt-area .txt2 .icon-x{display: inline-block; width: 14px; height: 11px; margin-left: 3px; background: url(../images/sub/icon-x-gray.svg) no-repeat center / contain; font-size: 0; text-indent: -9999%; overflow: hidden;}
 .section2.about .sec2-txt-area .logo{width: 100%; margin-top: 40px;}
 .section2.about .sec2-txt-area .logo > img{display: block; width: 100%;}
-
-.section3.about{margin-top:80px; padding: 0 20px;}
+/* 2022-12-21 수정 시작 */
+.section3.about{margin-top:77px; padding: 0 20px;}
+.section3.about .sec3-brand-area{margin-top:6px;}
+/* // 2022-12-21 수정 끝 */
 .section3.about .inner{padding-top: 0;}
 .section3.about .tit{font-size: 30px; line-height: 62px;}
 /* 2022-12-20 수정 시작 */
@@ -468,20 +546,27 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .section3.about .sec3-ani-box .motions{position: absolute; top: 0; left: 0; right: 0; bottom: 0; opacity: 0; transition: opacity 0.2s;}
 .section3.about .sec3-ani-box .motions svg {width: 100%; height: 100%;} */
 
-
-.section4.about{margin-top: 80px; padding: 0 20px;}
+/* 2022-12-21 수정 시작 */
+.section4.about{margin-top: 71px; padding: 0 20px;}
+/* // 2022-12-21 수정 끝 */
 .section4.about .inner{padding-top: 0; padding-bottom: 80px;}
 .section4.about .tit{font-size: 30px; line-height: 62px;}
-.section4.about .sec3-ci-area {width: 100%;}
+/* 2022-12-21 수정 시작 */
+.section4.about .sec3-ci-area {width: 100%;margin-top:5px;}
+/* // 2022-12-21 수정 끝 */
 /* 2022-12-20 수정 시작 */
 .section4.about .sec3-ci-area .logo-wrap{display: flex; align-items: center; flex-direction: column; width: 100%; border: 1px solid #111; background: url(../images/sub/img-ablout-ci-bg.svg) repeat-x center / auto 100%;}
 /* // 2022-12-20 수정 끝 */
 .section4.about .sec3-ci-area .logo-wrap .logo{width: 100%; background-color: #191919;}
 .section4.about .sec3-ci-area .logo-wrap .logo > img{display: block; margin: 0 auto;}
 .section4.about .sec3-ci-area .btn-wrap{display: flex; flex-direction: column; margin: 15px 0 0 0;}
-.section4.about .sec3-ci-area .btn-wrap .btn-down{position: relative; width: 100%; margin-bottom: 10px; color: #919191; font-size: 14px; line-height: 34px;}
+/* 2022-12-21 수정 시작 */
+.section4.about .sec3-ci-area .btn-wrap .btn-down{position: relative; width: 100%; margin-bottom: 8px; color: #919191; font-size: 14px; line-height: 34px;}
+/* // 2022-12-21 수정 끝 */
 .section4.about .sec3-ci-area .btn-wrap .btn-down:last-child{margin-bottom: 0;}
-.section4.about .sec3-ci-area .btn-wrap .btn-down .btn-inn{/* padding: 15px 110px; */ padding: 15px 0; border: 1px solid #444;}
+/* 2022-12-21 수정 시작 */
+.section4.about .sec3-ci-area .btn-wrap .btn-down .btn-inn{padding: 10px 0; border: 1px solid #444;}
+/* // 2022-12-21 수정 끝 */
 .section4.about .sec3-ci-area .btn-wrap .btn-down .btn-inn .btn-ico{position: relative; display: inline-block;}
 .section4.about .sec3-ci-area .btn-wrap .btn-down .btn-inn .btn-ico::after{content: ''; display: block; position: absolute; width: 24px; height: 24px; top: calc(50% - 12px); right: -30px; background: url(../images/sub/icon-download-919191.svg) no-repeat center / contain;}
 .section4.about .sec3-ci-area .btn-wrap .btn-down > span{font-family: 'Poppins', sans-serif;}
@@ -489,12 +574,17 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 
 /* partners */
 .partners-list-wrap{margin-top: 40px;margin-left: 20px; margin-right: 20px;}
+/* 2022-12-21 추가 시작 */
+.partners-list-wrap ~ .contents-pagination.type2 {margin-top:92px;}
+/* // 2022-12-21 추가 끝 */
 .partners-list-wrap .normal-list{}
 .partners-list-wrap .normal-list > ul{}
 .partners-list-wrap .normal-list > ul > li{padding: 0; box-sizing: border-box;}
 .partners-list-wrap .normal-list > ul > li .partners-box{position: relative; background-color: #191919;}
-.partners-list-wrap .normal-list > ul > li .partners-tit{margin-top: 12px; margin-bottom: 26px; font-size: 14px; color: #919191; text-align: center;}
-.partners-list-wrap .normal-list > ul > li .partners-box .partners-logo{padding-top: 60px; padding-bottom: 60px; text-align: center;}
+/* 2022-12-21 수정 시작 */
+.partners-list-wrap .normal-list > ul > li .partners-tit{margin-top: 10px; margin-bottom: 28px; font-size: 14px; color: #919191; text-align: center;}
+.partners-list-wrap .normal-list > ul > li .partners-box .partners-logo{padding-top: 50px; padding-bottom: 50px; text-align: center;}
+/* // 2022-12-21 수정 끝 */
 .partners-list-wrap .normal-list > ul > li .partners-box .partners-logo.mp-logo1 img{width: 160px; height: 60px;}
 .partners-list-wrap .normal-list > ul > li .partners-box .partners-logo.mp-logo2 img{width: 136px; height: 60px;}
 .partners-list-wrap .normal-list > ul > li .partners-box .partners-logo.mp-logo3 img{width: 160px; height: 60px;}
@@ -507,10 +597,10 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .partners-list-wrap .normal-list > ul > li .partners-box .partners-logo.mp-logo10 img{width: 180px; height: 60px;}
 .partners-list-wrap .normal-list > ul > li .partners-box .partners-logo.mp-logo11 img{width: 130px; height: 60px;}
 .partners-list-wrap .normal-list > ul > li .partners-box .partners-logo.mp-logo12 img{width: 60px; height: 60px;}
-/* 2022-12-20 v2 추가 시작 */
+/* 2022-12-21 수정 시작 */
 .partners-list-wrap .normal-list > ul > li .partners-box .partners-logo.mp-logo13 img{width: auto;max-width: 100%; height: 80px;}
-.partners-list-wrap .normal-list > ul > li .partners-box13 .partners-logo {padding:50px 0}
-/* // 2022-12-20 v2 추가 끝 */
+.partners-list-wrap .normal-list > ul > li .partners-box13 .partners-logo {padding:40px 0}
+/* // 2022-12-21 수정 끝 */
 
 /* contact */
 .list-sns {margin-top:-6px;font-size:0;}
@@ -525,7 +615,9 @@ a.btn-layerClose {display: inline-block;height: 25px;padding: 0 14px 0;border: 1
 .news-contents-slide {overflow:hidden;margin:0 -10px 16px;position: relative;}
 .news-contents-slide .swiper-slide {padding: 0 10px}
 .news-contents-slide .contents-img {margin-bottom: 0;}
-.news-contents-slide .contents-img-txt{margin-top:10px;font-size:12px;color:#919191;line-height: 1.5;}
+/* 2022-12-21 수정 시작 */
+.news-contents-slide .contents-img-txt{margin-top:8px;font-size:12px;color:#919191;line-height: 1.5;}
+/* // 2022-12-21 수정 끝 */
 
 .news-contents-slide .btn-prev ,
 .news-contents-slide .btn-next {position: absolute;margin-top:-50px;  top:50%;z-index:10;width: 24px;height:24px;background-position: 0 0;background-repeat: no-repeat;  background-size: 24px 24px}

--- a/efhiefh2ui344fwe/mobile/css/main2.css
+++ b/efhiefh2ui344fwe/mobile/css/main2.css
@@ -45,9 +45,13 @@ h1, h2, h3, h4, h5 {margin:0}
 .section2 .works-slide .swiper-slide {position:relative; width:28.6rem!important; margin:0 1rem}
 .section2 .works-slide .works-item-wrap {position:relative}
 .section2 .works-slide .works-item-wrap > a {display:block; position:absolute; left:0; right:0; top:0; bottom:0}
-.section2 .works-slide .item-tit {margin-top:1.6rem; color:#fff; font-size:2rem; font-weight:500; line-height:3rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+/* 2022-12-21 수정 시작 */
+.section2 .works-slide .item-tit {margin-top:1.4rem; color:#fff; font-size:2rem; font-weight:500; line-height:3rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+/* // 2022-12-21 수정 끝 */
 .section2 .works-slide .item-flag {position:absolute; top:0; right:0; display:block; min-width:8rem; padding:0 1.8rem; background-color:#DBFC00; color:#000; font-family:'Poppins', sans-serif; font-size:1.2rem; font-weight:bold; line-height:3rem; text-align:center}
-.section2 .works-slide .scrollbar {height:1px; margin-top:4rem; background-color:rgba(255,255,255,0.5)}
+/* 2022-12-21 수정 시작 */
+.section2 .works-slide .scrollbar {height:1px; margin:3.9rem 1rem 0; background-color:rgba(255,255,255,0.5)}
+/* // 2022-12-21 수정 끝 */
 .section2 .works-slide .scrollbar .swiper-scrollbar-drag {background-color:#DBFC00}
 
 .section3 .s-container {position:relative; width:100%; height:100%; overflow:hidden}
@@ -60,15 +64,22 @@ h1, h2, h3, h4, h5 {margin:0}
 .section3 .video-container video {position:absolute; width:auto; min-width:100%; height:auto; min-height:100%; top:0; bottom:0; left:50%; transform:translateX(-50%)}
 .section3 .sec-txt-area {position:absolute; left:0; right:0; top:0; bottom:0; width:100%; margin:0 auto; opacity:0; transition:all 0.6s}
 .section3 .sec-txt-area > a {display:block; position:absolute; left:0; right:0; top:0; bottom:0; z-index:500}
-.section3 .sec-txt {position:absolute; left:2rem; right:2rem; top:10rem; color:#fff; font-size:1.4rem; line-height:2.2rem; z-index:5}
-.section3 .sec-tit-wrap {position:absolute; left:2rem; right:2rem; bottom:8.5rem; z-index:6}
+/* 2022-12-21 수정 시작 */
+.section3 .sec-txt {position:absolute; left:2rem; right:2rem; top:10rem; color:#fff; font-size:1.4rem; line-height:1.4285; z-index:5;/* letter-spacing: 1px; */}
+.section3 .sec-txt .eng {letter-spacing: 0;}
+.section3 .sec-tit-wrap {position:absolute; left:2rem; right:2rem; bottom:8rem; z-index:6}
+/* // 2022-12-21 수정 끝 */
 .section3 .sec-tit {display:block; color:#fff; font-family:'Poppins', sans-serif; font-size:5rem; font-weight:normal; line-height:6rem}
-.section3 .view-more {display:block; width:6rem; height:6rem; margin-top:1.3rem; background:url(../images/img-main2-view-more.svg) no-repeat center / contain; font-size:0; text-indent:-9999%; overflow:hidden}
+/* 2022-12-21 수정 시작 */
+.section3 .view-more {display:block; width:6rem; height:6rem; margin-top:1.5rem; background:url(../images/img-main2-view-more.svg) no-repeat center / contain; font-size:0; text-indent:-9999%; overflow:hidden;}
+/* // 2022-12-21 수정 끝 */
 
 .section4 .section-inner {height:100%; padding-top:10rem}
 .section4 .tit-area {padding:0 2rem}
 .section4 .tit-area .tit {color:#fff; font-family:'Poppins', sans-serif; font-size:4rem; font-weight:normal; line-height:5.6rem}
-.section4 .btn-more {position:relative; margin-top:0.9rem; padding-right:2.2rem; color:#DBFC00; font-family:'Poppins', sans-serif; font-size:1.2rem; line-height:1.6rem}
+/* 2022-12-21 수정 시작 */
+.section4 .btn-more {display:inline-block; position:relative; margin-top:0.9rem; padding-right:2.2rem; color:#DBFC00; font-family:'Poppins', sans-serif; font-size:1.2rem; line-height:1.6rem}
+/* // 2022-12-21 수정 끝 */
 .section4 .btn-more::after {content:''; display:block; position:absolute; width:1.6rem; height:1.6rem; bottom:0; right:0; background:url(../images/img-arrow-right-green.svg) no-repeat center / contain}
 .section4 .partners-slide {width:100%; margin:16rem 0; overflow:hidden}
 .section4 .partners-slide .swiper-slide {width:auto!important}

--- a/efhiefh2ui344fwe/page_list.html
+++ b/efhiefh2ui344fwe/page_list.html
@@ -628,9 +628,15 @@
                           <li>+ main2.html 각 섹션 타이틀이 대문자로 변경되었습니다.<br>
                           <li>+ 하단 파트너스 슬라이드 좌우 여백이 수정되었습니다.
                         </ul>
+                        <br>
+
+                        <strong>2022/12/21</strong>
+                        <ul>
+                          <li>+ STUDIO X+U 텍스트를 class="eng" 요소로 감았습니다.<br><span class="eng">STUDIO X+U</span></li>
+                        </ul>
                       </td>
                     </tr>
-                    <tr>
+                    <tr class="row-done">
                       <th scope="row" class="col-num"></th>
                       <td></td>
                       <td>ABOUT</td>
@@ -638,7 +644,11 @@
                       <td></td>
                       <td></td>
                       <td><a href="html_m/about.html" target="_blank">about.html</a></td>
-                      <td>2022/12/16<br>2022/12/20 v2</td>
+                      <td>
+                        2022/12/16<br>
+                        2022/12/20 v2<br>
+                        2022/12/21
+                      </td>
                       <td></td>
                       <td class="etc">
                         <strong>2022/12/16</strong>
@@ -651,6 +661,13 @@
                         <strong>2022/12/20 v2</strong>
                         <ul>
                           <li>+ about.html 카드 내부 모션이 추가되고 카드 타이틀 색상이 수정되었습니다.</li>
+                        </ul>
+                        <br>
+
+                        <strong>2022/12/21</strong>
+                        <ul>
+                          <li>+ STUDIO X+U 텍스트를 class="eng" 요소로 감았습니다.<br><span class="eng">STUDIO X+U</span></li>
+                          <li>+ 즐거움을 배가하고 새로움을 더하다 앞의 &lt;br&gt; 태그를 삭제하였습니다.</li>
                         </ul>
                       </td>
                     </tr>
@@ -719,6 +736,12 @@
                         <ul>
                           <li>+ works.html 타이틀이 대문자로 변경되었습니다.</li>
                           <li>+ works_view.html 하단 Back to list 텍스트가 목록으로 수정되었습니다.</li>
+                        </ul>
+                        <br>
+
+                        <strong>2022/12/201</strong>
+                        <ul>
+                          <li>+ div class="pagination-wrap mt0"에서 mt0 HTML 클래스명이 삭제되었습니다.</li>
                         </ul>
                       </td>
                     </tr>


### PR DESCRIPTION
2022-12-21

MO-Front(국문)
[CSS]
여백, 폰트, 레이아웃을 맞췄기 때문에 common.css, main2.css 파일이 수정되었습니다.

수정된 파일 자체를 덮어씌우기 해주세요.
* 혹시 모를 개발계와 다른 부분이 있을 수 있으니 개발계 CSS 파일을 백업 후 진행해 주세요.

[HTML]
+ main2.html
- STUDIO X+U 텍스트를 class="eng" 요소로 감았습니다.

+ about.html
- STUDIO X+U 텍스트를 class="eng" 요소로 감았습니다.
- 즐거움을 배가하고 새로움을 더하다 앞의 <br>태그를 삭제하였습니다.

+ works.html
- <div class="pagination-wrap mt0">에서 mt0 HTML 클래스명이 삭제되었습니다.

2022-12-21로 검색하시어 html 파일에서 추가/수정된 부분을 반영해주세요.